### PR TITLE
Add further requirements to build on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ A Native Application for your OS to run your own IPFS Node. Built with [Electron
 
 ## Install
 
-You will need [Node.js](https://nodejs.org/en/) installed. Preferrably a version `>=4.0`. Also you will need [npm](npmjs.org) `>=3.0`. After that you should run
+You will need [Node.js](https://nodejs.org/en/) installed, preferrably a version `>=4.0`. On macOS you may also need Xcode command line tools, which can be installed with
+
+```bash
+xcode-select --install # Install Command Line Tools if you haven't already.
+sudo xcode-select --switch /Library/Developer/CommandLineTools # Enable command line tools
+```
+
+Also you will need [npm](npmjs.org) `>=3.0`. After that you should run
 
 ```bash
 $ git clone https://github.com/ipfs/station.git


### PR DESCRIPTION
In #517 I ran into a barrier in building station. With @VictorBjelkholm's guidance, I was able to install the dependencies and get up-and-running. Adding this change to the README would help others get going quicker.