### PR TITLE
Update conventions link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ $ npm run lint
 ```
 
 When you are ready to commit please be sure to follow the
-[commit convention](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md).
+[commit convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md).
 
 ## Available Scripts
 


### PR DESCRIPTION
In #519, the CONTRIBUTING file suggests adhering to a conventions file when submitting a PR. The link to this file is broken in the Station CONTRIBUTING.md. This PR updates the link. 

As the originally linked page no longer exists, I am unsure if this was the intended link, but based on the now-changed project structure, the new URI is my best guess as to what was intended.