### PR TITLE
Fix permissions + exit on error

### DIFF
--- a/postinst.sh
+++ b/postinst.sh
@@ -1,1 +1,4 @@
+#! /usr/bin/env bash
+set -e
 chmod 755 /usr/lib/ipfs-station/resources/app/node_modules/go-ipfs-dep/go-ipfs/ipfs
+echo "Changed permissions correctly"


### PR DESCRIPTION
Changes the permission of the script, makes sure we exit directly when something fails and debug output for when things are OK.