### PR TITLE
chore: add appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "9"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run lint
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@
 environment:
   nodejs_version: "9"
 
+# Tests only agains 64 bits since go-ipfs doesnt support 
+# 32 bits on Windows right now.
 platform:
   - x64
 
@@ -17,7 +19,7 @@ test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
-  # run tests
+  # Run lint and Make
   - npm run lint
   - npm run make
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ install:
   # install modules
   - npm install
 
+platform:
+  - x64
+
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
@@ -16,6 +19,7 @@ test_script:
   - npm --version
   # run tests
   - npm run lint
+  - npm run make
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,15 @@
 environment:
   nodejs_version: "9"
 
+platform:
+  - x64
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:platform
   # install modules
   - npm install
-
-platform:
-  - x64
 
 # Post-install test scripts.
 test_script:


### PR DESCRIPTION
Enables AppVeyor. It:

1. Runs `lint` to check if the code is syntactically OK.
2. Runs `make` to check if the code is buildable on Windows 64 bits.